### PR TITLE
Add support for creating and joining rooms

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -16,7 +16,8 @@ const initialState = {
 		userName: null,
     token: null,
     shouldSaveState: false,
-		userName: null
+		userName: null,
+		rooms: []
 }
 
 const App = () => {

--- a/src/api/CreateRoom.js
+++ b/src/api/CreateRoom.js
@@ -1,0 +1,22 @@
+import apiUrl from '../apiConfig'
+import axios from 'axios'
+// import React, { useContext } from 'react'
+// import AppContext from '../context/context'
+
+const createRoom = (roomName, id, token) => {
+  return axios({
+    method: 'POST',
+    url: apiUrl + '/create-room',
+    headers: {
+      Authorization: `Bearer ${token}`
+    },
+    data: {
+      room: {
+        name: roomName
+      },
+      userId: id
+    }
+  })
+}
+
+export default createRoom

--- a/src/components/Main/MainContent.js
+++ b/src/components/Main/MainContent.js
@@ -5,6 +5,7 @@ import { Container, Row, Col, Form, DropdownButton, ButtonGroup } from 'react-bo
 import Input from './MsgInput'
 import Message from './MessageJSX'
 import createRoom from '../../api/CreateRoom'
+import { SET_ROOMS_ID } from '../../context/action-types'
 
 const AlwaysScrollToBottom = () => {
 	const elementRef = createRef()
@@ -21,23 +22,27 @@ const MainContent = () => {
   const [newMessageObj, setNewMessageObj] = useState(null)
   const [roomName, setRoomName] = useState('')
   const { rooms } = state
-  // let roomJSX
+  const [roomsJSX, setRoomsJSX] = useState(null)
 
-  if (rooms) {
-    const roomJSX = rooms.map(room => (
-      <Link to={`/${room._id}`}>{`${room.name}`}</Link>
-    ))
-  }
+  useEffect(() => {
+    if (rooms) {
+      console.log(rooms)
+      setRoomsJSX(rooms.map(room => (
+        <Link to={`/${room._id}`}>{`${room.name}`}</Link>
+      )))
+    }
+  }, [rooms])
 
   const onCreateRoom = async (event) => {
     event.preventDefault()
+    let newArray = []
     console.log(roomName, state.userId)
     const room = await createRoom(roomName, state.userId, state.token)
     if (rooms.length > 0) {
-      const newArray = [...rooms]
+      newArray = [...rooms]
       newArray.push(room.data.room)
     } else {
-      const newArray = [room]
+      newArray = [room.data.room]
     }
     dispatch({
       type: SET_ROOMS_ID,
@@ -111,7 +116,7 @@ const MainContent = () => {
             <Row>
               {/* TODO: Make this into its own component */}
               <section className='open-rooms'>
-                {/* {roomsJSX} */}
+                {roomsJSX}
               </section>
             </Row>
         </Col>

--- a/src/components/Main/MainContent.js
+++ b/src/components/Main/MainContent.js
@@ -1,20 +1,76 @@
-import React, { useContext } from 'react' 
+import React, { useState, useContext } from 'react' 
+import { Link } from 'react-router-dom'
 import AppContext from '../../context/context'
-import { Container, Row, Col } from 'react-bootstrap'
+import { Container, Row, Col, Form, DropdownButton, ButtonGroup } from 'react-bootstrap'
 import Room from '../auth/Rooms'
+import createRoom from '../../api/CreateRoom'
 
 const MainContent = () => {
   const { state, dispatch } = useContext(AppContext)
+  const [roomName, setRoomName] = useState('')
+  const { roomArray } = state
+  // let roomJSX
+
+  if (state.rooms) {
+    const roomJSX = state.rooms.map(room => (
+      <Link to={`/${room._id}`}>{`${room.name}`}</Link>
+    ))
+  }
+
+  const onCreateRoom = async (event) => {
+    event.preventDefault()
+    console.log(roomName, state.userId)
+    const room = await createRoom(roomName, state.userId, state.token)
+    const newArray = [...roomArray]
+    newArray.push(newRoom)
+    dispatch({
+      type: SET_ROOMS_ID,
+      payload: newArray
+    })
+    // state.rooms.push(room.data.room)
+    console.log(room)
+  }
 
   return (
     <Container>
       {/* Second row - will contain rooms/DMs as well as main content */}
       <Row className='top-row'>
         <Col className='left-side-nav col-2'>
-            <h4>Rooms</h4>
-            <section className='open-rooms'>
-              <a href='#'>Room 1</a>
-            </section>
+            <Row>
+              <Col><h4>Rooms</h4></Col>
+              <Col>
+              <DropdownButton
+                as={ButtonGroup}
+                key={'end'}
+                id={`dropdown-button-drop-end`}
+                drop={'end'}
+                variant="secondary"
+                title={<img src='https://icongr.am/clarity/add.svg?size=16' />}
+                >
+                  {/* <Dropdown.Item eventKey='1' as='form' > */}
+                  <Form onSubmit={onCreateRoom}>
+                    <Form.Group controlId='room-name'>
+                      <Form.Control 
+                        required
+                        type='room-name' 
+                        name='create-room'
+                        value={roomName}
+                        placeholder='Enter Room Name'
+                        onChange={(e) => setRoomName(e.target.value)} 
+                      />
+                      <button type='submit'>Create</button>
+                    </Form.Group>
+                  </Form>
+                {/* </Dropdown.Item> */}
+                </DropdownButton>
+              </Col>
+            </Row>
+            <Row>
+              {/* TODO: Make this into its own component */}
+              <section className='open-rooms'>
+                {/* {roomsJSX} */}
+              </section>
+            </Row>
         </Col>
         <Col className='main-content col-9'>
             <section className='messages-window'>

--- a/src/components/Main/MainContent.js
+++ b/src/components/Main/MainContent.js
@@ -20,11 +20,11 @@ const MainContent = () => {
   const [components, setComponents] = useState([])
   const [newMessageObj, setNewMessageObj] = useState(null)
   const [roomName, setRoomName] = useState('')
-  const { roomArray } = state
+  const { rooms } = state
   // let roomJSX
 
-  if (state.rooms) {
-    const roomJSX = state.rooms.map(room => (
+  if (rooms) {
+    const roomJSX = rooms.map(room => (
       <Link to={`/${room._id}`}>{`${room.name}`}</Link>
     ))
   }
@@ -33,8 +33,12 @@ const MainContent = () => {
     event.preventDefault()
     console.log(roomName, state.userId)
     const room = await createRoom(roomName, state.userId, state.token)
-    const newArray = [...roomArray]
-    newArray.push(newRoom)
+    if (rooms.length > 0) {
+      const newArray = [...rooms]
+      newArray.push(room.data.room)
+    } else {
+      const newArray = [room]
+    }
     dispatch({
       type: SET_ROOMS_ID,
       payload: newArray


### PR DESCRIPTION
Co-authored-by: Jonah Saltzman jonahsaltzman@gmail.com

Includes:
- adding dropdown button that includes an input field to create a new room with your desired name
- making an API call to the /create-room endpoint and passing in the correct parameters to create the room
- updating the appContext to include the newly added room
- re-rendering the 'Rooms' list with all rooms in the appContext array