### PR TITLE
Add support for multiple rooms, multiple changes

### DIFF
--- a/src/components/Main/MainContent.js
+++ b/src/components/Main/MainContent.js
@@ -4,6 +4,7 @@ import AppContext from '../../context/context'
 import { Container, Row, Col, Form, DropdownButton, ButtonGroup } from 'react-bootstrap'
 import Input from './MsgInput'
 import Message from './MessageJSX'
+import RoomTitle from './RoomTitle'
 import createRoom from '../../api/CreateRoom'
 import showRooms from '../../api/ShowRooms'
 import { SET_ROOMS_ID } from '../../context/action-types'
@@ -26,10 +27,13 @@ const MainContent = () => {
   const [roomsJSX, setRoomsJSX] = useState(null)
   const [currentRoom, setCurrentRoom] = useState('')
   const [changedRoom, setChangedRoom] = useState('')
+  const [currentRoomName, setCurrentRoomName] = useState('')
+  const [changedRoomName, setChangedRoomName] = useState('')
 
-  const changeRoom = (roomId) => {
+  const changeRoom = (roomId, roomName) => {
     console.log('changing room to: ', roomId)
     setChangedRoom(roomId)
+    setChangedRoomName(roomName)
   }
 
   useEffect(() => {
@@ -37,7 +41,9 @@ const MainContent = () => {
     if (changedRoom === currentRoom) {
       return
     } else {
+      setMessages([])
       setCurrentRoom(changedRoom)
+      setCurrentRoomName(changedRoomName)
     }
   }, [changedRoom])
 
@@ -46,7 +52,7 @@ const MainContent = () => {
       console.log(rooms)
       setRoomsJSX(rooms.map(room => (
         <li key={`${room._id}`}>
-          <a href='#' onClick={changeRoom(room._id)}>{`${room.name}`}</a>
+          <a href='#' onClick={() => changeRoom(room._id, room.name)}>{`${room.name}`}</a>
         </li>
       )))
     }
@@ -57,13 +63,13 @@ const MainContent = () => {
     const response = await showRooms(token)
     const existingRooms = response.data.room
     console.log('existing rooms: ', existingRooms, 'saved rooms: ', rooms)
-    if (!rooms[0]) {
+    if (!rooms || !rooms[0]) {
       existingRooms.forEach(existingRoom => {
         if (existingRoom.validUsers.includes(userId)) {
           newArray.push(existingRoom)
         }
       })
-      setCurrentRoom(newArray[0])
+      // setCurrentRoom(newArray[0]._id)
     }
     console.log(newArray)
     dispatch({
@@ -172,9 +178,12 @@ const MainContent = () => {
             </Row>
         </Col>
         <Col className='main-content col-9'>
+          <Row>
+            <RoomTitle room={currentRoomName} />
+          </Row>
             <section className='messages-window'>
               <ul className='messages'>
-                {components}
+                {currentRoom ? components : 'No room selected. Please join a room to start a conversation!'}
                 <AlwaysScrollToBottom />
               </ul>
             </section>

--- a/src/components/Main/MsgInput.js
+++ b/src/components/Main/MsgInput.js
@@ -50,7 +50,7 @@ const MsgInput = ({received, room}) => {
   // Join a room
   // TODO
   useEffect(() => {
-    console.log('seeing this pop up here as well')
+    console.log('seeing this pop up here as well', room)
     if (room) {
       socket.emit('join', { roomId: room })
     }
@@ -75,10 +75,17 @@ const MsgInput = ({received, room}) => {
   }
 
   return (
-		<form className='message-input-window' onSubmit={sendMessage}>
-			<input value={messageText} onChange={(e) => setMessageText(e.target.value)} className='message-input' />
-			<button type='submit' className='send-message'>Send</button>
-		</form>
+		<>
+			{room !== '' ? 
+      
+        <form className='message-input-window' onSubmit={sendMessage}>
+          <input value={messageText} onChange={(e) => setMessageText(e.target.value)} className='message-input' />
+          <button type='submit' className='send-message'>Send</button>
+        </form>
+        
+       : '' }
+    </>
+		
 	)
   // Version requiring auth:
   // return loggedIn

--- a/src/components/Main/RoomTitle.js
+++ b/src/components/Main/RoomTitle.js
@@ -1,0 +1,20 @@
+import React, { useEffect } from 'react'
+
+const RoomTitle = ({ room }) => {
+
+  useEffect(() => {
+    console.log('in room: ', room)
+  }, [room])
+
+  return (
+    <>
+      {room ? 
+        <h3 className='room-title'>{room}</h3>
+        :
+        ''
+      }
+    </>
+  )
+}
+
+export default RoomTitle


### PR DESCRIPTION
Co-authored-by: Jonah Saltzman jonahsaltzman@gmail.com
Co-authored-by: Ayoub Mammeri aymammeri@gmail.com

Changes include:
- user can now join individual rooms and send messages in those rooms only
- Rooms are defined by their mongoose IDs for easy reference on both front and back end
- If not joined into a room, the input and send fields will disappear and a message will show on the main screen reading "no room selected. Please join a room to start a conversation!"
- Room title will show at the top of the page upon joining a room
- Messages from a previous room will now clear upon changing rooms, only the messages in your current room will show in the main message scren